### PR TITLE
compact: removes "undefined" properties

### DIFF
--- a/lib/obbie/compact.js
+++ b/lib/obbie/compact.js
@@ -15,7 +15,7 @@
  */
 const compact = object => Object.entries(object)
   .reduce((newObject, [key, value]) => {
-    if (value !== null) {
+    if (value !== null && value !== undefined) {
       newObject[key] = value
     }
 

--- a/tests/obbie/compact.test.js
+++ b/tests/obbie/compact.test.js
@@ -2,15 +2,19 @@ import compact from '../../lib/obbie/compact'
 
 const object = {
   a: 1,
-  b: 2,
-  c: null
+  b: 2
 }
 
 describe('compact', () => {
   it('removes "null" values on given object', () => {
-    expect(compact(object)).toMatchObject({
-      a: 1,
-      b: 2
-    })
+    const objectWithNullProperty = Object.assign({}, object, { c: null })
+
+    expect(compact(objectWithNullProperty)).toMatchObject(object)
+  })
+
+  it('removes "undefined" values on given object', () => {
+    const objectWithUndefinedProperty = Object.assign({}, object, { c: undefined })
+
+    expect(compact(objectWithUndefinedProperty)).toMatchObject(object)
   })
 })


### PR DESCRIPTION
The `compact` method used to fail in cases where the user explicitly specifies a property of the object should be `undefined`.

```javascript
const objectWithUndefined = { a: 1, b: undefined }

compact(objectWithUndefined) //=> { a: 1, b: undefined }
```

The changes made now support the removal of explicit `undefined` properties. The example above now should look like this:


```javascript
const objectWithUndefined = { a: 1, b: undefined }

compact(objectWithUndefined) //=> { a: 1 }
```