### PR TITLE
feat: eslint with jsdoc support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     "jest": true
   },
   "plugins": [
-    "jest"
+    "jest",
+    "jsdoc"
   ],
   "extends": "eslint:recommended",
   "parserOptions": {
@@ -29,6 +30,19 @@
     "semi": [
       "error",
       "never"
-    ]
+    ],
+    "jsdoc/check-param-names": 1,
+    "jsdoc/check-tag-names": 1,
+    "jsdoc/check-types": 1,
+    "jsdoc/newline-after-description": 1,
+    "jsdoc/require-description-complete-sentence": 1,
+    "jsdoc/require-example": 1,
+    "jsdoc/require-hyphen-before-param-description": 0,
+    "jsdoc/require-param": 1,
+    "jsdoc/require-param-description": 1,
+    "jsdoc/require-param-name": 1,
+    "jsdoc/require-param-type": 1,
+    "jsdoc/require-returns-description": 1,
+    "jsdoc/require-returns-type": 1
   }
 }

--- a/lib/obbie/compact.js
+++ b/lib/obbie/compact.js
@@ -5,9 +5,9 @@
  * @memberof Obbie
  *
  * @param {Object} object
- *   The object to be compacted
+ *   The object to be compacted.
  * @returns {Object}
- *   The object without first layer "null" values
+ *   The object without first layer "null" values.
  *
  * @example
  *   Obbie.compact({ a: null, b: { c: null } })

--- a/lib/obbie/dig.js
+++ b/lib/obbie/dig.js
@@ -5,11 +5,11 @@
  * @memberof Obbie
  *
  * @param {Object} object
- *   The object to execute the search
- * @param {String|Number|Array} keySequence
- *   The key sequence to be searched in the object
+ *   The object to execute the search.
+ * @param {string|number|Array} keySequence
+ *   The key sequence to be searched in the object.
  * @returns {*}
- *   The value of the key sequence searched in the object
+ *   The value of the key sequence searched in the object.
  *
  * @example
  *   Obbie.dig({ a: [{ b: 1 }] }, 'a', 0, 'b')

--- a/lib/obbie/length.js
+++ b/lib/obbie/length.js
@@ -5,9 +5,9 @@
  * @memberof Obbie
  *
  * @param {Object} object
- *   The object to have keys counted
- * @returns {Number}
- *   The amount of keys counted in the object
+ *   The object to have keys counted.
+ * @returns {number}
+ *   The amount of keys counted in the object.
  *
  * @example
  *   Obbie.length({ a: 1, b: 2, c: undefined })

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.13.1",
     "eslint-plugin-jest": "^21.5.0",
+    "eslint-plugin-jsdoc": "^3.6.3",
     "jest": "^21.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,6 +991,12 @@ commander@^2.11.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
+comment-parser@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.4.2.tgz#fa5a3f78013070114866dc7b8e9cf317a9635f74"
+  dependencies:
+    readable-stream "^2.0.4"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1169,6 +1175,14 @@ escodegen@^1.6.1:
 eslint-plugin-jest@^21.5.0:
   version "21.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz#c7a3bd2ee9d1c832b4e31dec89f6ad93e08d4853"
+
+eslint-plugin-jsdoc@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.6.3.tgz#8ac4b962964c2893fb0f58c621904203f07bd462"
+  dependencies:
+    comment-parser "^0.4.2"
+    jsdoctypeparser "^2.0.0-alpha-8"
+    lodash "^4.17.4"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -2152,6 +2166,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsdoctypeparser@^2.0.0-alpha-8:
+  version "2.0.0-alpha-8"
+  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz#baf137fb8e2a558810adcf19d2d2a2f680e90a5f"
+
 jsdom@^9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
@@ -2671,6 +2689,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -2751,6 +2773,18 @@ readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.4:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -3083,6 +3117,12 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 


### PR DESCRIPTION
The explicit rules should be removed in the future, since those are default in `jsdoc:recommended` rules, only being explicit because of an error that can be reproducible following these steps:

1. change `"extends"` value to: `["eslint:recommended", "plugin:jsdoc/recommended"]`
2. run ESLint: `yarn eslint lib/ tests/`

It should throw:

```
Cannot read property 'globalScope' of undefined
TypeError: Cannot read property 'globalScope' of undefined
```