### PR TITLE
Update Node versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
-  "7"
+  - "lts/dubnium"
+  - "lts/carbon"
+
 after_script:
   - yarn jest --coverage --coverageReporters=text-lcov | yarn coveralls


### PR DESCRIPTION
Right now, it only supports the two latest LTS builds. I'll support the others gracefully.