### PR TITLE
Refactor "deleteIf"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,10 @@
       "error",
       "unix"
     ],
+    "no-unused-vars": [
+      "error",
+      { "varsIgnorePattern": "^_$" }
+    ],
     "quotes": [
       "error",
       "single"

--- a/lib/obbie/deleteIf.js
+++ b/lib/obbie/deleteIf.js
@@ -20,15 +20,17 @@
  * //=> { a: 1, b: 2, c: 3 }
  */
 const deleteIf = (object, expectation = (() => {})) => {
-  let objectCopy = JSON.parse(JSON.stringify(object))
+  let result = object
 
-  for (let key in objectCopy) {
-    if (expectation(objectCopy[key])) {
-      delete objectCopy[key]
+  for (let key in object) {
+    if (expectation(key, object[key])) {
+      const { [key]: _, ...newObject } = object
+
+      result = newObject
     }
   }
 
-  return objectCopy
+  return result
 }
 
 export default deleteIf

--- a/tests/obbie/deleteIf.test.js
+++ b/tests/obbie/deleteIf.test.js
@@ -3,24 +3,26 @@ import deleteIf from '../../lib/obbie/deleteIf'
 const object = {
   a: 1,
   b: 2,
-  c: 3
+  c: 3,
+  d: {
+    e: 1
+  }
 }
 
 describe('deleteIf', () => {
   it('deletes the object entries matching a given expectation', () => {
     const removeEvenEntries = (_, value) => value % 2 === 0
 
-    expect(deleteIf(object, removeEvenEntries)).toMatchObject({
-      a: 1,
-      c: 3
-    })
+    expect(deleteIf(object, removeEvenEntries)).not.toHaveProperty('b')
+  })
+
+  it('deletes deep entries matching a given expectation', () => {
+    const removeDeepEntry = (_, value) => value && value.e === 1
+
+    expect(deleteIf(object, removeDeepEntry)).not.toHaveProperty('d')
   })
 
   it('returns the original object if no expectation is given', () => {
-    expect(deleteIf(object)).toMatchObject({
-      a: 1,
-      b: 2,
-      c: 3
-    })
+    expect(deleteIf(object)).toMatchObject(object)
   })
 })


### PR DESCRIPTION
This PR aims to not mutate the original object passed at `deleteIf`. The tests were simplified and adapted to handle nested properties. 